### PR TITLE
value testing is broken after code cleanup

### DIFF
--- a/Classes/Command/ComplexDataHandlerCommand.php
+++ b/Classes/Command/ComplexDataHandlerCommand.php
@@ -54,7 +54,7 @@ class ComplexDataHandlerCommand extends Command
             }
         }
 
-        if ((is_array($value)) === false) {
+        if ($value === 0 && (is_array($value)) === false) {
             $output->writeln('value is 0 or can not be decoded as array');
             return parent::FAILURE;
         }


### PR DESCRIPTION
The value could be an integer greater 0 or an array.
That was broken since https://github.com/in2code-de/migration/commit/bb6330210cc93703b592abd1d892d8acaab2a645