### PR TITLE
[FEATURE] Add second constructor parameter to migrator class with specific migration info

### DIFF
--- a/Classes/Migration/Start.php
+++ b/Classes/Migration/Start.php
@@ -53,7 +53,7 @@ class Start
                 );
             }
             /** @var MigratorInterface $migration */
-            $migration = GeneralUtility::makeInstance($migration['className'], $configuration);
+            $migration = GeneralUtility::makeInstance($migration['className'], $configuration, $migration);
             $migration->start();
         }
     }


### PR DESCRIPTION
When the `$migration['className']` is the same for few migrators then there is no way to get `$migration` info from all migrators `$configuration` table because there is no info which migrator is currently run.

`$migration = GeneralUtility::makeInstance($migration['className'], $configuration);`

The solution is simple. Just add third param with speocific $migration config. 

`$migration = GeneralUtility::makeInstance($migration['className'], $configuration, $migration);`