### PR TITLE
[BUGFIX] Respect TCA rootLevel setting

### DIFF
--- a/Classes/Port/Import.php
+++ b/Classes/Port/Import.php
@@ -16,6 +16,7 @@ use In2code\Migration\Port\Service\LinkMappingService;
 use In2code\Migration\Port\Service\MappingService;
 use In2code\Migration\Utility\DatabaseUtility;
 use In2code\Migration\Utility\FileUtility;
+use In2code\Migration\Utility\TcaUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -497,7 +498,8 @@ class Import
         if (DatabaseUtility::isFieldExistingInTable('tstamp', $tableName) === true) {
             $properties['tstamp'] = time();
         }
-        if (DatabaseUtility::isFieldExistingInTable('pid', $tableName) === true) {
+        if (DatabaseUtility::isFieldExistingInTable('pid', $tableName) === true
+            && TcaUtility::getRootLevelConfiguration($tableName) !== 1) {
             $newPid = $this->mappingService->getNewPidFromOldPid((int)$properties['pid']);
             if ($newPid > 0 || $properties['pid'] === $this->getFirstPid()) {
                 $properties['pid'] = $newPid;

--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -34,6 +34,11 @@ class TcaUtility
         return $tables;
     }
 
+    public static function getRootLevelConfiguration(string $tableName): int
+    {
+        return (int)($GLOBALS['TCA'][$tableName]['ctrl']['rootLevel'] ?? 0);
+    }
+
     protected static function getAllTableNames(): array
     {
         return array_keys($GLOBALS['TCA']);


### PR DESCRIPTION
Target pid is adjusted during imports, as the TCA rootLevel setting is not considered the pid is e.g. adjusted for sys_file_metadata, this will cause errors if not imported to root page (=0).

By checking the TCA rootLevel setting of the imported tables and skipping the adjustment for all tables that can only exist in the root, this issue is fixed.

Resolves: #37